### PR TITLE
Implement mood-based playlist MVP

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,13 @@
+# Spotify credentials
+SPOTIFY_CLIENT_ID=
+SPOTIFY_CLIENT_SECRET=
+
+# Stripe credentials
+STRIPE_SECRET_KEY=
+STRIPE_WEBHOOK_SECRET=
+
+# SendGrid
+SENDGRID_API_KEY=
+
+# OpenAI
+OPENAI_API_KEY=

--- a/README.md
+++ b/README.md
@@ -1,0 +1,20 @@
+# Vibrate
+
+Mood-based playlist generator using OpenAI and Spotify.
+
+## Setup
+
+1. Install dependencies:
+   ```bash
+   npm install
+   (cd app && npm install)
+   ```
+2. Copy `.env.example` to `.env` and fill in credentials.
+3. Run development servers:
+   ```bash
+   npm run dev
+   ```
+
+## Deployment
+
+Deploy to Vercel. The `api` directory contains serverless functions and the `app` directory is a Vite React frontend.

--- a/api/generate.js
+++ b/api/generate.js
@@ -1,0 +1,54 @@
+const fetch = require('node-fetch');
+
+async function getUserToken(userId) {
+  // TODO: retrieve stored OAuth token for user
+  return { access_token: process.env.SPOTIFY_ACCESS_TOKEN };
+}
+
+module.exports = async (req, res) => {
+  if (req.method !== 'POST') return res.status(405).end();
+  const { userId, seeds } = req.body;
+
+  // TODO: check trial/subscription status
+
+  const { access_token } = await getUserToken(userId);
+
+  const params = new URLSearchParams({
+    seed_artists: seeds.seed_artists.join(','),
+    seed_genres: seeds.seed_genres.join(','),
+    target_valence: seeds.target_valence,
+    target_energy: seeds.target_energy,
+    target_tempo: seeds.target_tempo,
+    limit: 20
+  });
+
+  const recRes = await fetch(`https://api.spotify.com/v1/recommendations?${params}`, {
+    headers: { Authorization: `Bearer ${access_token}` }
+  });
+  const rec = await recRes.json();
+  const uris = rec.tracks.map(t => t.uri);
+
+  const playlistRes = await fetch(`https://api.spotify.com/v1/users/${userId}/playlists`, {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${access_token}`,
+      'Content-Type': 'application/json'
+    },
+    body: JSON.stringify({ name: 'Vibrate Playlist', public: false })
+  });
+  const playlist = await playlistRes.json();
+
+  await fetch(`https://api.spotify.com/v1/playlists/${playlist.id}/tracks`, {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${access_token}`,
+      'Content-Type': 'application/json'
+    },
+    body: JSON.stringify({ uris })
+  });
+
+  res.status(200).json({
+    embedUrl: `https://open.spotify.com/embed/playlist/${playlist.id}`,
+    playlistId: playlist.id
+  });
+};

--- a/api/index.js
+++ b/api/index.js
@@ -1,0 +1,17 @@
+const express = require('express');
+const bodyParser = require('body-parser');
+const seed = require('./seed');
+const generate = require('./generate');
+const signup = require('./signup');
+const stripeWebhook = require('./webhooks/stripe');
+
+const app = express();
+app.use(bodyParser.json({ verify: (req, res, buf) => { req.rawBody = buf; } }));
+
+app.post('/api/seed', seed);
+app.post('/api/generate', generate);
+app.post('/api/signup', signup);
+app.post('/api/webhooks/stripe', stripeWebhook);
+
+const port = process.env.PORT || 3000;
+app.listen(port, () => console.log(`API listening on ${port}`));

--- a/api/seed.js
+++ b/api/seed.js
@@ -1,0 +1,20 @@
+const { Configuration, OpenAIApi } = require('openai');
+
+module.exports = async (req, res) => {
+  if (req.method !== 'POST') return res.status(405).end();
+  const { vibe } = req.body;
+  const configuration = new Configuration({ apiKey: process.env.OPENAI_API_KEY });
+  const openai = new OpenAIApi(configuration);
+
+  try {
+    const prompt = `Return Spotify seed_artists, seed_genres, target_valence, target_energy, target_tempo as JSON for the vibe: ${vibe}`;
+    const completion = await openai.createChatCompletion({
+      model: 'gpt-3.5-turbo',
+      messages: [{ role: 'user', content: prompt }]
+    });
+    const json = JSON.parse(completion.data.choices[0].message.content);
+    res.status(200).json(json);
+  } catch (err) {
+    res.status(500).json({ error: 'failed' });
+  }
+};

--- a/api/signup.js
+++ b/api/signup.js
@@ -1,0 +1,33 @@
+const stripe = require('stripe')(process.env.STRIPE_SECRET_KEY);
+const sgMail = require('@sendgrid/mail');
+sgMail.setApiKey(process.env.SENDGRID_API_KEY);
+
+module.exports = async (req, res) => {
+  if (req.method !== 'POST') return res.status(405).end();
+  const { email, paymentMethodId } = req.body;
+
+  try {
+    const customer = await stripe.customers.create({
+      email,
+      payment_method: paymentMethodId,
+      invoice_settings: { default_payment_method: paymentMethodId }
+    });
+
+    const subscription = await stripe.subscriptions.create({
+      customer: customer.id,
+      items: [{ price: 'price_123' }],
+      trial_period_days: 7
+    });
+
+    await sgMail.send({
+      to: email,
+      from: 'noreply@vibrate.app',
+      subject: 'Welcome to Vibrate',
+      text: 'Enjoy your playlists!'
+    });
+
+    res.status(200).json({ customerId: customer.id, subscriptionId: subscription.id });
+  } catch (err) {
+    res.status(500).json({ error: 'signup failed' });
+  }
+};

--- a/api/webhooks/stripe.js
+++ b/api/webhooks/stripe.js
@@ -1,0 +1,22 @@
+const stripe = require('stripe')(process.env.STRIPE_SECRET_KEY);
+
+module.exports = async (req, res) => {
+  const sig = req.headers['stripe-signature'];
+  let event;
+  try {
+    event = stripe.webhooks.constructEvent(req.rawBody, sig, process.env.STRIPE_WEBHOOK_SECRET);
+  } catch (err) {
+    return res.status(400).send(`Webhook Error: ${err.message}`);
+  }
+
+  switch (event.type) {
+    case 'invoice.payment_succeeded':
+      // TODO: mark user as paid
+      break;
+    case 'customer.subscription.deleted':
+      // TODO: mark user as canceled
+      break;
+  }
+
+  res.json({ received: true });
+};

--- a/app/index.html
+++ b/app/index.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link rel="manifest" href="/manifest.json" />
+    <title>Vibrate</title>
+  </head>
+  <body class="bg-gray-900 text-white">
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/app/manifest.json
+++ b/app/manifest.json
@@ -1,0 +1,15 @@
+{
+  "name": "Vibrate",
+  "short_name": "Vibrate",
+  "start_url": "/",
+  "display": "standalone",
+  "background_color": "#000000",
+  "theme_color": "#000000",
+  "icons": [
+    {
+      "src": "icon-192.png",
+      "sizes": "192x192",
+      "type": "image/png"
+    }
+  ]
+}

--- a/app/package.json
+++ b/app/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "vibrate-app",
+  "private": true,
+  "version": "0.1.0",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  },
+  "devDependencies": {
+    "@types/react": "^18.0.27",
+    "@types/react-dom": "^18.0.10",
+    "@vitejs/plugin-react": "^4.0.0",
+    "autoprefixer": "^10.4.14",
+    "postcss": "^8.4.23",
+    "tailwindcss": "^3.3.2",
+    "typescript": "^5.0.4",
+    "vite": "^4.4.9"
+  }
+}

--- a/app/postcss.config.cjs
+++ b/app/postcss.config.cjs
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/app/service-worker.js
+++ b/app/service-worker.js
@@ -1,0 +1,2 @@
+self.addEventListener('install', () => self.skipWaiting());
+self.addEventListener('activate', () => self.clients.claim());

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -1,0 +1,57 @@
+import React, { useState } from 'react';
+import Input from './components/Input';
+import Playlist from './components/Playlist';
+import TrialBanner from './components/TrialBanner';
+import UpgradeModal from './components/UpgradeModal';
+
+interface SeedResponse {
+  seed_artists: string[];
+  seed_genres: string[];
+  target_valence: number;
+  target_energy: number;
+  target_tempo: number;
+}
+
+export default function App() {
+  const [vibe, setVibe] = useState('');
+  const [embedUrl, setEmbedUrl] = useState<string | null>(null);
+  const [trialDay, setTrialDay] = useState(1);
+  const [subscribed, setSubscribed] = useState(false);
+  const [showUpgrade, setShowUpgrade] = useState(false);
+
+  const generate = async () => {
+    const seedRes = await fetch('/api/seed', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ vibe })
+    });
+    const seeds: SeedResponse = await seedRes.json();
+    const genRes = await fetch('/api/generate', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ userId: 'me', seeds })
+    });
+    if (genRes.status === 402) {
+      setShowUpgrade(true);
+      return;
+    }
+    const data = await genRes.json();
+    setEmbedUrl(data.embedUrl);
+  };
+
+  return (
+    <div className="p-4 space-y-4">
+      <TrialBanner day={trialDay} subscribed={subscribed} />
+      <Input vibe={vibe} setVibe={setVibe} onGenerate={generate} />
+      <Playlist embedUrl={embedUrl} />
+      <UpgradeModal
+        open={showUpgrade}
+        onClose={() => setShowUpgrade(false)}
+        onUpgrade={() => {
+          setSubscribed(true);
+          setShowUpgrade(false);
+        }}
+      />
+    </div>
+  );
+}

--- a/app/src/components/Input.tsx
+++ b/app/src/components/Input.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+
+interface Props {
+  vibe: string;
+  setVibe: (v: string) => void;
+  onGenerate: () => void;
+}
+
+export default function Input({ vibe, setVibe, onGenerate }: Props) {
+  return (
+    <div className="space-x-2 flex">
+      <input
+        className="flex-1 p-2 rounded text-black"
+        placeholder="Type your vibe"
+        value={vibe}
+        onChange={e => setVibe(e.target.value)}
+      />
+      <button className="bg-green-600 px-4 py-2 rounded" onClick={onGenerate}>
+        Generate Playlist
+      </button>
+    </div>
+  );
+}

--- a/app/src/components/Playlist.tsx
+++ b/app/src/components/Playlist.tsx
@@ -1,0 +1,16 @@
+interface Props {
+  embedUrl: string | null;
+}
+
+export default function Playlist({ embedUrl }: Props) {
+  if (!embedUrl) return null;
+  return (
+    <iframe
+      src={embedUrl}
+      width="100%"
+      height="380"
+      allow="encrypted-media"
+      title="playlist"
+    ></iframe>
+  );
+}

--- a/app/src/components/TrialBanner.tsx
+++ b/app/src/components/TrialBanner.tsx
@@ -1,0 +1,15 @@
+interface Props {
+  day: number;
+  subscribed: boolean;
+}
+
+export default function TrialBanner({ day, subscribed }: Props) {
+  if (subscribed) {
+    return <span className="bg-green-700 px-2 py-1 rounded">Subscribed</span>;
+  }
+  return (
+    <div className="bg-yellow-600 px-2 py-1 rounded">
+      Day {day} of 7-day free trial
+    </div>
+  );
+}

--- a/app/src/components/UpgradeModal.tsx
+++ b/app/src/components/UpgradeModal.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+
+interface Props {
+  open: boolean;
+  onClose: () => void;
+  onUpgrade: () => void;
+}
+
+export default function UpgradeModal({ open, onClose, onUpgrade }: Props) {
+  if (!open) return null;
+  return (
+    <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center">
+      <div className="bg-white text-black p-4 rounded">
+        <h2 className="text-xl mb-2">Upgrade</h2>
+        <p className="mb-4">Subscribe to keep generating playlists.</p>
+        <button className="mr-2 bg-green-600 px-4 py-2 rounded text-white" onClick={onUpgrade}>Upgrade</button>
+        <button className="px-4 py-2" onClick={onClose}>Cancel</button>
+      </div>
+    </div>
+  );
+}

--- a/app/src/index.css
+++ b/app/src/index.css
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/app/src/main.tsx
+++ b/app/src/main.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App';
+import './index.css';
+
+ReactDOM.createRoot(document.getElementById('root')!).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);

--- a/app/tailwind.config.cjs
+++ b/app/tailwind.config.cjs
@@ -1,0 +1,7 @@
+module.exports = {
+  content: ['./index.html', './src/**/*.{js,ts,jsx,tsx}'],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+};

--- a/app/vite.config.js
+++ b/app/vite.config.js
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+  server: { port: 5173 }
+});

--- a/package.json
+++ b/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "vibrate",
+  "private": true,
+  "scripts": {
+    "dev": "concurrently \"npm --prefix app run dev\" \"nodemon api/index.js\"",
+    "build": "npm --prefix app run build",
+    "start": "node api/index.js"
+  },
+  "devDependencies": {
+    "concurrently": "^8.0.1",
+    "nodemon": "^2.0.22"
+  }
+}


### PR DESCRIPTION
## Summary
- scaffold Vite + React frontend with Tailwind and PWA assets
- add serverless API functions for OpenAI, Spotify, Stripe and SendGrid
- provide dev server via Express for local testing
- document setup and required environment variables

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_686585f511248328a6b965d233d8a740